### PR TITLE
Some changes with Search and Replace frame

### DIFF
--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -26,6 +26,7 @@
               :style="{width:sideMenuWidthPixel + 'px'}"
               style="height: 100%"
               @maximizeEditor="isEditorFullScreen = true"
+              @unHoverSideMenu="isSideMenuHovered=false"
             />
           </div>
           <div
@@ -82,7 +83,7 @@ export default {
   },
   created () {
     // cut textarea height to prevent overflow
-    const heightCutOffset = 70
+    const heightCutOffset = 75
     const widthCutOffset = 80
 
     // set textarea height on first open

--- a/src/renderer/components/DocumentHeaderPanel.vue
+++ b/src/renderer/components/DocumentHeaderPanel.vue
@@ -1,0 +1,32 @@
+<template>
+  <div id="document-header-panel">
+    <div id="title">
+      This is title
+    </div>
+    <v-spacer />
+    <SearchAndReplace />
+  </div>
+</template>
+
+<script>
+import SearchAndReplace from './SearchAndReplace'
+export default {
+  name: 'DocumentHeaderPanel',
+  components: {SearchAndReplace},
+
+}
+</script>
+
+<style scoped>
+#document-header-panel{
+  display: flex;
+}
+#title{
+  font-family: Roboto,serif;
+  font-style: normal;
+  font-weight: 900;
+  font-size: 36px;
+  line-height: 42px;
+  letter-spacing: -0.333333px;
+}
+</style>

--- a/src/renderer/components/EditItem.vue
+++ b/src/renderer/components/EditItem.vue
@@ -17,4 +17,7 @@ export default {
 </script>
 
 <style scoped>
+#content{
+  color:#545454;
+}
 </style>

--- a/src/renderer/components/EditPanel.vue
+++ b/src/renderer/components/EditPanel.vue
@@ -2,7 +2,7 @@
   <div id="edit-panel">
     <div id="edit-item-holder" />
     <EditItem
-      v-for="edit in edits.slice(0, 4)"
+      v-for="edit in edits.slice(0, 14)"
       id="edit-item"
       :key="edit.key"
       :content="edit.content"
@@ -23,6 +23,16 @@ export default {
         {key: 1, content: 'edit 2'},
         {key: 2, content: 'edit 3'},
         {key: 3, content: 'edit 4'},
+        {key: 4, content: 'edit 5'},
+        {key: 5, content: 'edit 6'},
+        {key: 6, content: 'edit 7'},
+        {key: 7, content: 'edit 8'},
+        {key: 8, content: 'edit 9'},
+        {key: 9, content: 'edit 10'},
+        {key: 10, content: 'edit 11'},
+        {key: 11, content: 'edit 12'},
+        {key: 12, content: 'edit 13'},
+        {key: 13, content: 'edit 14'},
       ]
     }
   }
@@ -44,9 +54,10 @@ export default {
   margin-left:13px;
   margin-right:13px;
   margin-bottom:2px;
+  user-select: none;
 }
 #edit-item-holder{
-  margin-top: 50px;
+  margin-top: 40px;
 }
 </style>
 

--- a/src/renderer/components/Editor.vue
+++ b/src/renderer/components/Editor.vue
@@ -1,15 +1,23 @@
 <template>
   <div id="editor">
-    <TextArea />
+    <div id="content-box">
+      <DocumentHeaderPanel />
+      <div id="time">
+        2021/02/27
+      </div>
+      <div id="deco_underline" />
+      <TextArea />
+    </div>
   </div>
 </template>
 
 <script>
 import TextArea from './TextArea'
+import DocumentHeaderPanel from './DocumentHeaderPanel'
 
 export default {
   name: 'Editor',
-  components: {TextArea},
+  components: {TextArea,DocumentHeaderPanel},
   id: 'editor'
 }
 </script>
@@ -17,6 +25,25 @@ export default {
 <style scoped>
 #editor{
   height: 100%;
+  background: #F7F7F7;
+  border-radius: 12px;
 }
-
+#content-box{
+  padding: 20px;
+}
+#time{
+  font-family: Roboto,serif;
+  font-style: normal;
+  font-weight: normal;
+  font-size: 12px;
+  line-height: 14px;
+  letter-spacing: -0.333333px;
+  padding-left: 3px;
+  padding-bottom: 3px;
+}
+#deco_underline{
+  width: 427px;
+  height: 0;
+  border: 1px solid #777777;
+}
 </style>

--- a/src/renderer/components/SearchAndReplace.vue
+++ b/src/renderer/components/SearchAndReplace.vue
@@ -1,0 +1,101 @@
+<template>
+  <div id="searchAndReplace">
+    <div id="search">
+      <v-icon
+        x-small
+        style="padding-left: 3px"
+      >
+        mdi-magnify
+      </v-icon>
+    </div>
+    <div id="searchAndReplace_deco" />
+    <div id="replace">
+      replace with
+    </div>
+    <v-btn
+      class="no-background-hover"
+      icon
+      x-small
+    >
+      <v-icon>mdi-magnify</v-icon>
+    </v-btn>
+    <v-btn
+      icon
+      class="no-background-hover"
+      x-small
+    >
+      <v-icon>mdi-file-replace-outline</v-icon>
+    </v-btn>
+    <v-btn
+      icon
+      class="no-background-hover"
+      x-small
+    >
+      <v-icon>mdi-find-replace</v-icon>
+    </v-btn>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'SearchAndReplace',
+}
+</script>
+
+<style scoped>
+#searchAndReplace{
+  width: 231px;
+  height: 28px;
+
+  background: #E8E8E8;
+  border-radius: 36px;
+  box-sizing: inherit;
+  display: flex;
+  align-items: center;
+  float:right !important;
+  font-size: 9px;
+  color: #A6A6A6;
+  text-indent:5%
+}
+#search {
+  width: 78px;
+  height: 20px;
+
+  background: #FFFFFF;
+  margin-left: 5px;
+  border-radius: 32px;
+  z-index: 10;
+  display: flex;
+  place-items: center;
+}
+#searchAndReplace_deco{
+  width: 33px;
+  height: 28px;
+
+  margin-left: -14px;
+  background: #E8E8E8;
+  border-radius: 36px;
+  z-index: 11;
+}
+#replace{
+  width: 77px;
+  height: 20px;
+
+  margin-left: -28px;
+  background: #FFFFFF;
+  border-radius: 36px;
+  z-index: 12;
+  display: flex;
+  place-items: center;
+}
+.no-background-hover {
+  width: 26px;
+  height: 26px;
+  float:right;
+  z-index:13
+}
+
+.no-background-hover::before {
+  background-color: transparent !important;
+}
+</style>

--- a/src/renderer/components/SideMenu.vue
+++ b/src/renderer/components/SideMenu.vue
@@ -5,6 +5,7 @@
     <ToolBar
       :is-side-menu-hovered="isSideMenuHovered"
       @turnOffSideMenu="$emit('maximizeEditor')"
+      @unHoverSideMenu="$emit('unHoverSideMenu')"
     />
     <EditPanel />
   </div>

--- a/src/renderer/components/TextArea.vue
+++ b/src/renderer/components/TextArea.vue
@@ -104,18 +104,15 @@ export default {
 
 <style scoped>
 #text-area {
-  height: 100%;
-  background: #F7F7F7;
-  border-radius: 12px;
 }
-
 .editor {
-  padding: 10px;
+  padding-top: 5px;
   width: 100%;
   height: 100%;
   resize: none;
   min-height: 10px;
   color: #545454;
+  font-size: 18px;
 }
 
 .editor:focus {

--- a/src/renderer/components/ToolBar.vue
+++ b/src/renderer/components/ToolBar.vue
@@ -41,6 +41,7 @@
         icon
         class="no-background-hover"
         large
+        @click="$emit('unHoverSideMenu')"
       >
         <v-icon>mdi-close-circle</v-icon>
       </v-btn>
@@ -82,6 +83,9 @@ export default {
     },
     turnOffSideMenu () {
       this.$emit('turnOffSideMenu')
+    },
+    unHoverSideMenu() {
+      this.$emit('unHoverSideMenu')
     }
   }
 


### PR DESCRIPTION
Just add a Document header panel, which includes the Search and Replace bar.  It basically looks the same as we designed.

For changes:
- Now you can cancel the hover when you in hovered mode. 
- You cannot select text in edits anymore.
- I moved some styling items from the text area to the editor.
- regrouped editor items into another <div> container in order to give some padding between editor items with the editor background.
- some layout changes.